### PR TITLE
Reserves additions

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,9 +22,10 @@
 			<p class="lead">Low level calculation of balances.</p>
 			<div class="input-group">
 				<input type="text" class="form-control" id="address"
-					value="14id3ENXVkJ34Q51AfWDGcMHA1EbGu8obF8QJLEUkzAB8KVh" />
+					value="EGVQCe73TpFyAZx5uKfE1222XfkT3BSKozjgcqzLBnc5eYo" />
 				<div class="input-group-append">
-					<a class="btn btn-lg btn-primary" onclick="calculateReserved();" role="button">Calculate Balance &raquo;</a>
+					<a class="btn btn-lg btn-primary" onclick="calculateReserved();" role="button">Calculate Balance
+						&raquo;</a>
 				</div>
 			</div>
 			<div class="row">
@@ -33,7 +34,7 @@
 						<div class="input-group-prepend">
 							<span class="input-group-text">Endpoint:</span>
 						</div>
-						<input type="text" class="form-control" id="endpoint" value="wss://rpc.polkadot.io/"
+						<input type="text" class="form-control" id="endpoint" value="wss://kusama-rpc.polkadot.io/"
 							placeholder="wss://..." />
 					</div>
 				</div>

--- a/index.html
+++ b/index.html
@@ -22,7 +22,7 @@
 			<p class="lead">Low level calculation of balances.</p>
 			<div class="input-group">
 				<input type="text" class="form-control" id="address"
-					value="EGVQCe73TpFyAZx5uKfE1222XfkT3BSKozjgcqzLBnc5eYo" />
+					value="14id3ENXVkJ34Q51AfWDGcMHA1EbGu8obF8QJLEUkzAB8KVh" />
 				<div class="input-group-append">
 					<a class="btn btn-lg btn-primary" onclick="calculateReserved();" role="button">Calculate Balance &raquo;</a>
 				</div>
@@ -33,7 +33,7 @@
 						<div class="input-group-prepend">
 							<span class="input-group-text">Endpoint:</span>
 						</div>
-						<input type="text" class="form-control" id="endpoint" value="wss://kusama-rpc.polkadot.io/"
+						<input type="text" class="form-control" id="endpoint" value="wss://rpc.polkadot.io/"
 							placeholder="wss://..." />
 					</div>
 				</div>
@@ -63,9 +63,9 @@
 
 	<!-- Custom JavaScript -->
 	<script src="https://cdn.plot.ly/plotly-latest.min.js"></script>
-	<script src="//unpkg.com/bn.js/lib/bn.js"></script>
-	<script src="//unpkg.com/polkadot-js-bundle/polkadot.js"></script>
-	<script src="//unpkg.com/bn/jsbn/jsbn.js"></script>
+	<script src="https://unpkg.com/bn.js/lib/bn.js"></script>
+	<script src="https://unpkg.com/polkadot-js-bundle/polkadot.js"></script>
+	<script src="https://unpkg.com/bn/jsbn/jsbn.js"></script>
 	<script src="./reserved.js"></script>
 </body>
 

--- a/reserved.js
+++ b/reserved.js
@@ -82,7 +82,6 @@ async function getDemocracyReserved() {
 	return deposit.add(preimageDeposit);
 }
 
-/*
 async function getElectionsReserved() {
 	if (!substrate.query.electionsPhragmen) {
 		console.log("No elections pallet.");
@@ -100,7 +99,6 @@ async function getElectionsReserved() {
 
 	return votingBond.add(candidateBond)
 }
-*/
 
 async function getPhragmenElectionReserved() {
 	if (!substrate.query.phragmenElection) {
@@ -404,7 +402,7 @@ async function calculateReserved() {
 
 	// Calculate the reserved balance pallet to pallet
 	reserved = reserved.add(await getDemocracyReserved());
-	//reserved = reserved.add(await getElectionsReserved());
+	reserved = reserved.add(await getElectionsReserved());
 	reserved = reserved.add(await getPhragmenElectionReserved());
 	reserved = reserved.add(await getIdentityReserved());
 	reserved = reserved.add(await getRegistrarReserved());

--- a/reserved.js
+++ b/reserved.js
@@ -71,6 +71,7 @@ async function getDemocracyReserved() {
 	return deposit.add(preimageDeposit);
 }
 
+/*
 async function getElectionsReserved() {
 	if (!substrate.query.electionsPhragmen) {
 		console.log("No elections pallet.");
@@ -87,6 +88,25 @@ async function getElectionsReserved() {
 	output.innerText += `Elections: Voting = ${toUnit(votingBond)}, Candidate = ${toUnit(candidateBond)}\n`;
 
 	return votingBond.add(candidateBond)
+}
+*/
+
+async function getPhragmenElectionReserved() {
+	if (!substrate.query.phragmenElection) {
+		console.log("No phragmen elections pallet.");
+		return new BN();
+	}
+
+	let voter = await substrate.query.phragmenElection.voting(global.address);
+
+	let deposit = new BN();
+	if (voter.deposit) {
+		deposit = deposit.add(voter.deposit);
+		console.log(deposit);
+	}
+	output.innerText += `Phragmen Elections: Deposit = ${toUnit(deposit)}\n`
+
+	return deposit;
 }
 
 async function getIdentityReserved() {
@@ -352,7 +372,8 @@ async function calculateReserved() {
 
 	// Calculate the reserved balance pallet to pallet
 	reserved = reserved.add(await getDemocracyReserved());
-	reserved = reserved.add(await getElectionsReserved());
+	//reserved = reserved.add(await getElectionsReserved());
+	reserved = reserved.add(await getPhragmenElectionReserved());
 	reserved = reserved.add(await getIdentityReserved());
 	reserved = reserved.add(await getRegistrarReserved());
 	reserved = reserved.add(await getIndicesReserved());

--- a/reserved.js
+++ b/reserved.js
@@ -15,7 +15,18 @@ function toUnit(balance) {
 	let decimals = global.chainDecimals;
 	base = new BN(10).pow(new BN(decimals));
 	dm = balance.divmod(base);
-	return dm.div.toString() + "." + dm.mod.abs().toString() + " " + global.chainToken
+	modulus = dm.mod.abs().toString();
+	if (!dm.mod.isZero()) {
+		const additionalZeros = decimals - modulus.length;
+		for (let i = 0; i < additionalZeros; i++) {
+			modulus = '0' + modulus; 
+		}
+	}
+	let sign = "";
+	if (dm.mod < 0) {
+		sign = "-";
+	}
+	return sign + dm.div.toString() + "." + modulus + " " + global.chainToken
 }
 
 // Connect to Substrate endpoint

--- a/reserved.js
+++ b/reserved.js
@@ -164,6 +164,27 @@ async function getRegistrarReserved() {
 	return deposit;
 }
 
+async function getCrowdloanReserved() {
+	if (!substrate.query.crowdloan) {
+		console.log("No crowdloan pallet.");
+		return new BN();
+	}
+
+	let deposit = new BN();
+	let crowdloans = await substrate.query.crowdloan.funds.entries();
+	for (let [key, crowdloan] of crowdloans) {
+		crowdloan = crowdloan.value;
+		let who = crowdloan.depositor;
+		let value = crowdloan.deposit;
+		if (util.u8aEq(who, global.address)) {
+			deposit = deposit.add(value);
+		}
+	}
+	output.innerText += `Crowdloan: Deposit = ${toUnit(deposit)}\n`
+
+	return deposit;
+}
+
 async function getIndicesReserved() {
 	if (!substrate.query.indices) {
 		console.log("No indices pallet.");
@@ -376,6 +397,7 @@ async function calculateReserved() {
 	reserved = reserved.add(await getPhragmenElectionReserved());
 	reserved = reserved.add(await getIdentityReserved());
 	reserved = reserved.add(await getRegistrarReserved());
+	reserved = reserved.add(await getCrowdloanReserved());
 	reserved = reserved.add(await getIndicesReserved());
 	reserved = reserved.add(await getMultisigReserved());
 	reserved = reserved.add(await getProxyReserved());

--- a/reserved.js
+++ b/reserved.js
@@ -97,11 +97,15 @@ async function getIdentityReserved() {
 
 	let registration = await substrate.query.identity.identityOf(global.address);
 	registration = registration.value;
+	let subIdentities = await substrate.query.identity.subsOf(global.address);
 
 	// Deposit for existing identity
 	let deposit = new BN();
+	// Deposit for any subidentities
+	let subDeposit = new BN();
 	if (registration.deposit) {
-		deposit = deposit.add(registration.deposit)
+		deposit = deposit.add(registration.deposit);
+		subDeposit = subDeposit.add(subIdentities[0]);
 	}
 
 	// Reserved fees for judgements
@@ -114,9 +118,9 @@ async function getIdentityReserved() {
 			}
 		}
 	}
-	output.innerText += `Identity: Deposit = ${toUnit(deposit)}, Fees = ${toUnit(fees)}\n`;
+	output.innerText += `Identity: Deposit = ${toUnit(deposit)}, Sub-identities Deposit = ${toUnit(subDeposit)}, Fees = ${toUnit(fees)}\n`;
 
-	return deposit.add(fees)
+	return deposit.add(fees).add(subDeposit);
 }
 
 async function getIndicesReserved() {

--- a/reserved.js
+++ b/reserved.js
@@ -123,6 +123,27 @@ async function getIdentityReserved() {
 	return deposit.add(fees).add(subDeposit);
 }
 
+async function getRegistrarReserved() {
+	if (!substrate.query.registrar) {
+		console.log("No registrar pallet.");
+		return new BN();
+	}
+
+	let deposit = new BN();
+	let paras = await substrate.query.registrar.paras.entries();
+	for (let [key, para] of paras) {
+		para = para.value;
+		let who = para.manager;
+		let value = para.deposit;
+		if (util.u8aEq(who, global.address)) {
+			deposit = deposit.add(value);
+		}
+	}
+	output.innerText += `Registrar: Deposit = ${toUnit(deposit)}\n`
+
+	return deposit;
+}
+
 async function getIndicesReserved() {
 	if (!substrate.query.indices) {
 		console.log("No indices pallet.");
@@ -333,6 +354,7 @@ async function calculateReserved() {
 	reserved = reserved.add(await getDemocracyReserved());
 	reserved = reserved.add(await getElectionsReserved());
 	reserved = reserved.add(await getIdentityReserved());
+	reserved = reserved.add(await getRegistrarReserved());
 	reserved = reserved.add(await getIndicesReserved());
 	reserved = reserved.add(await getMultisigReserved());
 	reserved = reserved.add(await getProxyReserved());

--- a/reserved.js
+++ b/reserved.js
@@ -67,7 +67,7 @@ async function getDemocracyReserved() {
 		}
 	}
 
-	output.innerText += `Democracy: Deposit = ${deposit}, Preimage = ${preimageDeposit}\n`;
+	output.innerText += `Democracy: Deposit = ${toUnit(deposit)}, Preimage = ${toUnit(preimageDeposit)}\n`;
 	return deposit.add(preimageDeposit);
 }
 
@@ -84,7 +84,7 @@ async function getElectionsReserved() {
 	let is_candidate = (await substrate.query.electionsPhragmen.candidates()).find((c) => util.u8aEq(c, global.address)) != undefined;
 	let candidateBond = is_member || is_runner_up || is_candidate ? substrate.consts.electionsPhragmen.candidacyBond : new BN();
 
-	output.innerText += `Elections: Voting = ${votingBond}, Candidate = ${candidateBond}\n`;
+	output.innerText += `Elections: Voting = ${toUnit(votingBond)}, Candidate = ${toUnit(candidateBond)}\n`;
 
 	return votingBond.add(candidateBond)
 }
@@ -114,7 +114,7 @@ async function getIdentityReserved() {
 			}
 		}
 	}
-	output.innerText += `Identity: Deposit = ${deposit}, Fees = ${fees}\n`;
+	output.innerText += `Identity: Deposit = ${toUnit(deposit)}, Fees = ${toUnit(fees)}\n`;
 
 	return deposit.add(fees)
 }
@@ -138,7 +138,7 @@ async function getIndicesReserved() {
 		}
 	}
 
-	output.innerText += `Indices: Deposit = ${deposit}\n`;
+	output.innerText += `Indices: Deposit = ${toUnit(deposit)}\n`;
 	return deposit;
 }
 
@@ -172,7 +172,7 @@ async function getMultisigReserved() {
 		}
 	}
 
-	output.innerText += `Multisig: Deposit = ${multisigDeposit}, Calls = ${callsDeposit}\n`;
+	output.innerText += `Multisig: Deposit = ${toUnit(multisigDeposit)}, Calls = ${toUnit(callsDeposit)}\n`;
 	return multisigDeposit.add(callsDeposit);
 }
 
@@ -193,7 +193,7 @@ async function getProxyReserved() {
 	announcementDeposit = announcementDeposit.add(announcementValue)
 
 	// TODO Anon vs delegator
-	output.innerText += `Proxy: Deposit = ${proxyDeposit}, Announcement = ${announcementDeposit}\n`;
+	output.innerText += `Proxy: Deposit = ${toUnit(proxyDeposit)}, Announcement = ${toUnit(announcementDeposit)}\n`;
 	return proxyDeposit.add(announcementDeposit);
 }
 
@@ -225,7 +225,7 @@ async function getRecoveryReserved() {
 		}
 	}
 
-	output.innerText += `Recovery: Recoverable = ${recoverableDeposit}, Active: ${activeDeposit}\n`;
+	output.innerText += `Recovery: Recoverable = ${toUnit(recoverableDeposit)}, Active: ${toUnit(activeDeposit)}\n`;
 	return recoverableDeposit.add(activeDeposit);
 }
 
@@ -245,7 +245,7 @@ async function getSocietyReserved() {
 		}
 	}
 
-	output.innerText += `Society: Bid Deposit = ${bidDeposit}\n`;
+	output.innerText += `Society: Bid Deposit = ${toUnit(bidDeposit)}\n`;
 	return bidDeposit;
 }
 
@@ -305,7 +305,7 @@ async function getTreasuryReserved() {
 		}
 	}
 
-	output.innerText += `Treasury: Proposal = ${proposalDeposit}, Tip = ${tipDeposit}, Bounty = ${bountyDeposit}, Curator = ${curatorDeposit}\n`;
+	output.innerText += `Treasury: Proposal = ${toUnit(proposalDeposit)}, Tip = ${toUnit(tipDeposit)}, Bounty = ${toUnit(bountyDeposit)}, Curator = ${toUnit(curatorDeposit)}\n`;
 	return proposalDeposit.add(tipDeposit).add(curatorDeposit);
 }
 


### PR DESCRIPTION
Changes in this PR:
- Added `https:` in front of the custom scripts (couldn't make it work otherwise)
- Set default address to mine and RPC to Polkadot in `index.html` (to test)
- Changed the display of all results to floats in the unit of the chain
- Fixed the decimals calculations in `toUnit`: leading zeros in the decimals weren't accounted for. Also, added a check for a negative result (from difference)
- Added `registrar` and `crowdloan` pallets
- Added reserves from sub-identities
- Replaced the `electionsPhragmen` pallet with `phragmenElection`